### PR TITLE
fixed paths in ner_hun_best.yaml

### DIFF
--- a/configs/ner_hun_best.yaml
+++ b/configs/ner_hun_best.yaml
@@ -293,25 +293,25 @@ features:
  - # Description: XXX Fill me!
     name: trainloc
     type: lex
-    actionName: hunner/lex/used/loc.fromtraincorpus.lex
+    actionName: hunner/lex/loc.fromtraincorpus.lex
     fields: 0
 
  - # Description: XXX Fill me!
     name: trainorg
     type: lex
-    actionName: hunner/lex/used/org.fromtraincorpus.lex
+    actionName: hunner/lex/org.fromtraincorpus.lex
     fields: 0
 
  - # Description: XXX Fill me!
     name: trainpers
     type: lex
-    actionName: hunner/lex/used/per.fromtraincorpus.lex
+    actionName: hunner/lex/per.fromtraincorpus.lex
     fields: 0
 
  - # Description: XXX Fill me!
     name: trainmisc
     type: lex
-    actionName: hunner/lex/used/misc.fromtraincorpus.lex
+    actionName: hunner/lex_from_Eszter.Simon/misc.fromtraincorpus.lex
     fields: 0
 
  #~ - # Description: XXX Fill me!


### PR DESCRIPTION
Path names of .lex files in the yaml config file did not work when training NER model in a clean clone of Huntag3. Now works with these fixes, approve or not @dlazesz 
